### PR TITLE
Fix prerender example DAG

### DIFF
--- a/dev/dags/prerender/example_prerender.py
+++ b/dev/dags/prerender/example_prerender.py
@@ -1,6 +1,12 @@
+import datetime
 from airflow.models import DAG
 from airflow.operators.empty import EmptyOperator
-with DAG(default_args={'start_date': datetime.date(2024, 1, 1)}, description='Example DAG for prerendering', dag_id='simple_prerender_dag') as dag:
-    task_a = EmptyOperator()
-    task_b = EmptyOperator()
+
+with DAG(
+    default_args={"start_date": datetime.datetime(2024, 1, 1)},
+    description="Example DAG for prerendering",
+    dag_id="simple_prerender_dag",
+) as dag:
+    task_a = EmptyOperator(task_id="task_a")
+    task_b = EmptyOperator(task_id="task_b")
     task_a >> task_b


### PR DESCRIPTION
## Summary
- fix the prerender example DAG so tests can parse it

## Testing
- `hatch run tests.py3.10-2.5:test-cov`
- `hatch run tests.py3.9-2.9:test-integration-setup`
- `hatch run tests.py3.9-2.9:test-integration`


------
https://chatgpt.com/codex/tasks/task_e_684033a56b3c8326ac88f942efc54413